### PR TITLE
[SC-30402] split dockerfiles based on mac arch

### DIFF
--- a/Dockerfile.M1
+++ b/Dockerfile.M1
@@ -1,0 +1,31 @@
+FROM arm64v8/maven:3.8.4-jdk-8-slim
+
+ENV GEN_DIR /opt/openapi-generator
+WORKDIR ${GEN_DIR}
+VOLUME  ${MAVEN_HOME}/.m2/repository
+
+# Required from a licensing standpoint
+COPY ./LICENSE ${GEN_DIR}
+
+# Required to compile openapi-generator
+COPY ./google_checkstyle.xml ${GEN_DIR}
+
+# Modules are copied individually here to allow for caching of docker layers between major.minor versions
+COPY ./modules/openapi-generator-gradle-plugin ${GEN_DIR}/modules/openapi-generator-gradle-plugin
+COPY ./modules/openapi-generator-maven-plugin ${GEN_DIR}/modules/openapi-generator-maven-plugin
+COPY ./modules/openapi-generator-online ${GEN_DIR}/modules/openapi-generator-online
+COPY ./modules/openapi-generator-cli ${GEN_DIR}/modules/openapi-generator-cli
+COPY ./modules/openapi-generator-core ${GEN_DIR}/modules/openapi-generator-core
+COPY ./modules/openapi-generator ${GEN_DIR}/modules/openapi-generator
+COPY ./pom.xml ${GEN_DIR}
+
+# Pre-compile openapi-generator-cli
+RUN mvn -am -pl "modules/openapi-generator-cli" package
+
+# This exists at the end of the file to benefit from cached layers when modifying docker-entrypoint.sh.
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s /usr/local/bin/docker-entrypoint.sh /usr/local/bin/openapi-generator
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["help"]


### PR DESCRIPTION
Moving this m1 change to the correct branch
<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
