### PR TITLE
always use 'body' for bodyParam name

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -27,7 +27,7 @@ export class {{classname}}Resource {
      {{#allParams}}{{^isCookieParam}}{{^isHeaderParam}}* @param {{paramName}} {{description}}
      {{/isHeaderParam}}{{/isCookieParam}}{{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{^isQueryParam}}{{^isCookieParam}}{{^isHeaderParam}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isHeaderParam}}{{/isCookieParam}}{{/isQueryParam}}{{/allParams}}{{#hasQueryParams}}query?: { {{#queryParams}}{{#lambda.snakecase_param}}{{paramName}}{{/lambda.snakecase_param}}{{^required}}?{{/required}}: {{{dataType}}}{{^-last}},{{/-last}} {{/queryParams}}}, {{/hasQueryParams}}axiosConfig?: AxiosRequestConfig): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+    public {{nickname}}({{#allParams}}{{^isQueryParam}}{{^isCookieParam}}{{^isHeaderParam}}{{^isBodyParam}}{{paramName}}{{/isBodyParam}}{{#isBodyParam}}body{{/isBodyParam}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isHeaderParam}}{{/isCookieParam}}{{/isQueryParam}}{{/allParams}}{{#hasQueryParams}}query?: { {{#queryParams}}{{#lambda.snakecase_param}}{{paramName}}{{/lambda.snakecase_param}}{{^required}}?{{/required}}: {{{dataType}}}{{^-last}},{{/-last}} {{/queryParams}}}, {{/hasQueryParams}}axiosConfig?: AxiosRequestConfig): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const reqPath = '{{path}}'{{#pathParams}}
                     .replace('{' + '{{baseName}}}', String({{paramName}}{{#isDateTime}}.toISOString(){{/isDateTime}})){{/pathParams}};
 {{#hasFormParams}}
@@ -42,7 +42,7 @@ export class {{classname}}Resource {
             method: '{{httpMethod}}' as Method,
             url: reqPath{{#hasQueryParams}},
             params: query{{/hasQueryParams}}{{#bodyParam}},
-            data: {{paramName}}{{/bodyParam}}{{#hasFormParams}},
+            data: body{{/bodyParam}}{{#hasFormParams}},
             headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
             data: stringify(reqFormParams)
 {{/hasFormParams}}


### PR DESCRIPTION
This PR updates the codegen template to use `body` for the body param in the generated API calls instead of a unique name based on the Python code.  This should not have any impact other than aesthetics where the param names could become very long, especially in the case of `Union` input params where the name was formed by concatenating each member of the union, resulting in names like `userPaymentMethodUpdateBankAccountVerificationRequestUserPaymentMethodUpdateFundingAttestationRequest`.