### PR TITLE
Throw custom MambaApiError when Axios raises

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -28,7 +28,8 @@ export class {{classname}}Resource {
      {{/isHeaderParam}}{{/isCookieParam}}{{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{^isQueryParam}}{{^isCookieParam}}{{^isHeaderParam}}{{^isBodyParam}}{{paramName}}{{/isBodyParam}}{{#isBodyParam}}body{{/isBodyParam}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isHeaderParam}}{{/isCookieParam}}{{/isQueryParam}}{{/allParams}}{{#hasQueryParams}}query?: { {{#queryParams}}{{#lambda.snakecase_param}}{{paramName}}{{/lambda.snakecase_param}}{{^required}}?{{/required}}: {{{dataType}}}{{^-last}},{{/-last}} {{/queryParams}}}, {{/hasQueryParams}}axiosConfig?: AxiosRequestConfig): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-        const reqPath = '{{path}}'{{#pathParams}}
+        const parameterizedPath = '{{path}}';
+        const reqPath = parameterizedPath{{#pathParams}}
                     .replace('{' + '{{baseName}}}', String({{paramName}}{{#isDateTime}}.toISOString(){{/isDateTime}})){{/pathParams}};
 {{#hasFormParams}}
         let reqFormParams = {
@@ -40,6 +41,7 @@ export class {{classname}}Resource {
         let reqConfig = {
             ...axiosConfig,
             method: '{{httpMethod}}' as Method,
+            parameterizedPath,
             url: reqPath{{#hasQueryParams}},
             params: query{{/hasQueryParams}}{{#bodyParam}},
             data: body{{/bodyParam}}{{#hasFormParams}},

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -38,7 +38,7 @@ export class {{classname}}Resource {
 {{/formParams}}
         };
 {{/hasFormParams}}
-        let reqConfig = {
+        const reqConfig = {
             ...axiosConfig,
             method: '{{httpMethod}}' as Method,
             parameterizedPath,

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -46,7 +46,7 @@ export class {{classname}}Resource {
             params: query{{/hasQueryParams}}{{#bodyParam}},
             data: body{{/bodyParam}}{{#hasFormParams}},
             headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
-            data: stringify(reqFormParams)
+            data: stringify(reqFormParams),
 {{/hasFormParams}}
 
         };

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -1,6 +1,7 @@
 {{>licenseInfo}}
-import { AxiosRequestConfig, Method } from 'axios';
-import { axios } from '../axios.config';
+import axios, { AxiosRequestConfig, Method } from 'axios';
+
+import { axios as axiosClient, MambaApiError } from '../axios.config';
 {{#hasFormParams}}
 import { stringify } from 'qs';
 {{/hasFormParams}}
@@ -28,8 +29,8 @@ export class {{classname}}Resource {
      {{/isHeaderParam}}{{/isCookieParam}}{{/allParams}}
      */
     public {{nickname}}({{#allParams}}{{^isQueryParam}}{{^isCookieParam}}{{^isHeaderParam}}{{^isBodyParam}}{{paramName}}{{/isBodyParam}}{{#isBodyParam}}body{{/isBodyParam}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isHeaderParam}}{{/isCookieParam}}{{/isQueryParam}}{{/allParams}}{{#hasQueryParams}}query?: { {{#queryParams}}{{#lambda.snakecase_param}}{{paramName}}{{/lambda.snakecase_param}}{{^required}}?{{/required}}: {{{dataType}}}{{^-last}},{{/-last}} {{/queryParams}}}, {{/hasQueryParams}}axiosConfig?: AxiosRequestConfig): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-        const parameterizedPath = '{{path}}';
-        const reqPath = parameterizedPath{{#pathParams}}
+        const apiRoute = '{{path}}';
+        const reqPath = apiRoute{{#pathParams}}
                     .replace('{' + '{{baseName}}}', String({{paramName}}{{#isDateTime}}.toISOString(){{/isDateTime}})){{/pathParams}};
 {{#hasFormParams}}
         let reqFormParams = {
@@ -41,7 +42,6 @@ export class {{classname}}Resource {
         const reqConfig = {
             ...axiosConfig,
             method: '{{httpMethod}}' as Method,
-            parameterizedPath,
             url: reqPath{{#hasQueryParams}},
             params: query{{/hasQueryParams}}{{#bodyParam}},
             data: body{{/bodyParam}}{{#hasFormParams}},
@@ -50,9 +50,16 @@ export class {{classname}}Resource {
 {{/hasFormParams}}
 
         };
-        return axios.request(reqConfig)
+        return axiosClient.request(reqConfig)
             .then(res => {
                 return res.data;
+            })
+            .catch(error => {
+                if (axios.isAxiosError(error)) {
+                    throw new MambaApiError({ apiRoute, error });
+                } else {
+                    throw error;
+                }
             });
     }
 


### PR DESCRIPTION
Updates the Axios error handling to throw a new, custom error, `MambaApiError`, and include the API route in Mamba (e.g., `/my-resource/{resource_id}`) when instantiating the new error. 

This property will be used in the client apps to help instrument Sentry to better group error events.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
