### PR TITLE
Fix typo

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -51,7 +51,7 @@ export class {{classname}}Resource {
 
         };
 
-        let originalStacktrace: string | null = new Error().stack ?? null;
+        let originalStackTrace: string | null = new Error().stack ?? null;
 
         return axiosClient.request(reqConfig)
             .then(res => {
@@ -64,9 +64,9 @@ export class {{classname}}Resource {
 
                     // this will not include Axios' library code which is the source of the error.
                     // if we ever want to do that, we can use `${formattedError.stack}\n{originalStackTrace}
-                    formattedError.stack = originalStacktrace || formattedError.stack;
+                    formattedError.stack = originalStackTrace || formattedError.stack;
 
-                    originalStacktrace = null;
+                    originalStackTrace = null;
 
                     throw formattedError;
                 }


### PR DESCRIPTION
Fix inconsistent `stacktrace` casing. Settled on `stackTrace`<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date.sh
  ``` 
  Commit all changed files.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
