### PR TITLE
support enum and references in general

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
@@ -2,7 +2,7 @@
 {{#models}}
 {{#model}}
 {{#tsImports}}
-import { {{classname}} } from './{{filename}}';
+import { {{classname}}, {{classname}}Metadata } from './{{filename}}';
 {{/tsImports}}{{#description}}
 /* {{{description}}} */{{/description}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}
 {{/model}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -13,14 +13,16 @@ export enum {{classname}} {
 {{/allowableValues}}
 }
 
-
 export const {{classname}}Metadata: EnumMetadata<{{classname}}> = {
+    metadataType: 'enum',
     name: '{{classname}}',
     values: {
-        {{#allowableValues}}
-        {{#enumVars}}
-            {{{name}}}: {{{value}}}{{^-last}},{{/-last}}
-        {{/enumVars}}
-        {{/allowableValues}}
+        {{#vendorExtensions.x-enum-metadata}}
+        [{{classname}}.{{name}}]: {
+            name: "{{name}}",
+            value: {{classname}}.{{name}},
+            label: "{{label}}"  
+        },
+        {{/vendorExtensions.x-enum-metadata}}
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -29,17 +29,22 @@ export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}
 
 
 export const {{classname}}Metadata: ModelMetadata<{{classname}}> = {
+    metadataType: 'model',
     name: '{{classname}}',
     properties: {
         {{#vars}}
             {{name}}: {
                 title: '{{#title}}{{title}}{{/title}}{{^title}}{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}{{/title}}',
-                type: '{{openApiType}}',
-                {{#dataFormat}}format: '{{dataFormat}}',{{/dataFormat}}
-                isEnum: {{#allowableValues}}true{{/allowableValues}}{{^allowableValues}}{{isEnum}}{{/allowableValues}}{{#isModel}},
-                isReference: true,
-                referenceType: '{{baseType}}'{{/isModel}}
+                type: '{{{openApiType}}}',{{#isListContainer}}
+                arrayOf: '{{items.dataType}}',{{/isListContainer}}{{#dataFormat}}
+                format: '{{dataFormat}}',{{/dataFormat}}
+                required: {{required}},
             },
         {{/vars}}
+    },
+    references: {
+    {{#tsImports}}
+        "{{classname}}": {{classname}}Metadata,
+    {{/tsImports}}
     }
 }


### PR DESCRIPTION
Updates the metadata generation templates to support enums, references and required items. I added `required` to avoid having to update the templates again for something we know we'll need.

this is part 1, part 2 will be in a PR in the monorepo, but this needs to be merged first so I have a commit hash to reference


<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
