### PR TITLE
[PATIENT-3037] Remove custom axios stacktrace

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -51,26 +51,14 @@ export class {{classname}}Resource {
 
         };
 
-        let originalStackTrace: string | null = new Error().stack ?? null;
-
         return axiosClient.request(reqConfig)
             .then(res => {
-                originalStackTrace = null
                 return res.data;
             })
             .catch(error => {
                 if (axios.isAxiosError(error)) {
-                    const formattedError = new MambaApiError({ apiRoute, error });
-
-                    // this will not include Axios' library code which is the source of the error.
-                    // if we ever want to do that, we can use `${formattedError.stack}\n{originalStackTrace}
-                    formattedError.stack = originalStackTrace || formattedError.stack;
-
-                    originalStackTrace = null;
-
-                    throw formattedError;
+                    throw new MambaApiError({ apiRoute, error });
                 }
-
                 throw error;
             });
     }


### PR DESCRIPTION
Since axios 1.6.6 (Jan 2024), axios has better stacktrace handling so we don't need this custom logic anymore. It had an overhead of 20-400ms per request.

### PR checklist - from the OG open-api generator?

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
