### PR TITLE
fix list-of-enum codegen

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -11,7 +11,7 @@ export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}
      * {{{description}}}
      */
     {{/description}}
-    {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{classname}}{{enumName}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
+    {{name}}{{^required}}?{{/required}}: {{#isListContainer}}{{#isEnum}}Array<{{classname}}{{enumName}}>{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}{{/isListContainer}}{{^isListContainer}}{{#isEnum}}{{classname}}{{enumName}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}{{/isListContainer}}{{#isNullable}} | null{{/isNullable}};
 
 {{/vars}}
 }


### PR DESCRIPTION
Fixes a bug:

```py
Entitlement = Literal[....]
class SomeRequestBody(BaseModel):
    field: list[Entitlement]
```

was generating as:

```ts
interface SomeRequestBody {
    // BUG: should've been Array<>
    field: SomeRequestBodyField
}
enum SomeRequestBodyField { ... }
```

and now will be:

```ts
interface SomeRequestBody {
    field: Array<SomeRequestBodyField>
}
enum SomeRequestBodyField { ... }
```

I ran this on mamba; no other codegen output was affected