### PR TITLE
Support x-enum-as-union to generate spec enums as string unions instead of TS enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -18,15 +18,14 @@ export enum {{classname}} {
 }
 {{/vendorExtensions.x-enum-as-union}}
 
-{{! TODO: create a LiteralUnionMetadata for x-enum-as-union? }}
 export const {{classname}}Metadata: EnumMetadata<{{classname}}> = {
     metadataType: 'enum',
     name: '{{classname}}',
     values: {
         {{#vendorExtensions.x-enum-metadata}}
-        [{{classname}}.{{name}}]: {
+        [{{#vendorExtensions.x-enum-as-union}}"{{value}}"{{/vendorExtensions.x-enum-as-union}}{{^vendorExtensions.x-enum-as-union}}{{classname}}.{{name}}{{/vendorExtensions.x-enum-as-union}}]: {
             name: "{{name}}",
-            value: {{classname}}.{{name}},
+            value: {{#vendorExtensions.x-enum-as-union}}"{{value}}"{{/vendorExtensions.x-enum-as-union}}{{^vendorExtensions.x-enum-as-union}}{{classname}}.{{name}}{{/vendorExtensions.x-enum-as-union}},
             label: "{{label}}"
         },
         {{/vendorExtensions.x-enum-metadata}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -5,6 +5,10 @@ import {EnumMetadata} from '../metadata'
     * {{{description}}}
     */
 {{/description}}
+{{#vendorExtensions.x-enum-as-union}}
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+{{/vendorExtensions.x-enum-as-union}}
+{{^vendorExtensions.x-enum-as-union}}
 export enum {{classname}} {
 {{#allowableValues}}
 {{#enumVars}}
@@ -12,7 +16,9 @@ export enum {{classname}} {
 {{/enumVars}}
 {{/allowableValues}}
 }
+{{/vendorExtensions.x-enum-as-union}}
 
+{{! TODO: create a LiteralUnionMetadata for x-enum-as-union? }}
 export const {{classname}}Metadata: EnumMetadata<{{classname}}> = {
     metadataType: 'enum',
     name: '{{classname}}',
@@ -21,7 +27,7 @@ export const {{classname}}Metadata: EnumMetadata<{{classname}}> = {
         [{{classname}}.{{name}}]: {
             name: "{{name}}",
             value: {{classname}}.{{name}},
-            label: "{{label}}"  
+            label: "{{label}}"
         },
         {{/vendorExtensions.x-enum-metadata}}
     }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -18,13 +18,19 @@ export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}
 
 {{#hasEnums}}
 {{#vars}}{{#isEnum}}
+    {{#vendorExtensions.x-enum-as-union}}
+    export type {{classname}}{{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+    {{/vendorExtensions.x-enum-as-union}}
+    {{^vendorExtensions.x-enum-as-union}}
     export enum {{classname}}{{enumName}} {
     {{#allowableValues}}
         {{#enumVars}}
             {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
         {{/enumVars}}
     {{/allowableValues}}
-    }{{/isEnum}}{{/vars}}
+    }
+    {{/vendorExtensions.x-enum-as-union}}
+{{/isEnum}}{{/vars}}
 {{/hasEnums}}
 
 


### PR DESCRIPTION
In Python I have a large `Literal[...]` type where the literals include some punctuation. This is extremely unwieldy when generated as TS enums. So, I'm adding an option to generate them as regular TS string unions instead.


```py
Entitlement = Literal["a", "b", ...]
class SomeRequestBody(BaseModel):
    field: list[Entitlement]
```

was generating as:

```ts
interface SomeRequestBody {
    // BUG: should've been Array<>
    field: SomeRequestBodyEntitlement
}
enum SomeRequestBodyEntitlement {
    A = "a",
    B = "b"
}
```

and now will be:

```ts
interface SomeRequestBody {
    field: Array<SomeRequestBodyEntitlement>
}
type SomeRequestBodyEntitlement = "a" | "b" | ...;
```

I ran this on mamba; no other codegen output was affected